### PR TITLE
[COOK-3592] allow source port to be set as a range

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ Roles and the node may have the `['firewall']['rules']` attribute set. This attr
               "destination" => "1.2.3.5",
               "dest_port" => "5469"
             }
+          },
+          {"allow to tcp ports 8000-8010 from 192.168.1.0/24" => {
+              "port_range" => "8000..8010",
+              "source" => "192.168.1.0/24",
+              "protocol" => "tcp" //protocol is mandatory when using port ranges
+            }
           }
         ]
       }

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -58,12 +58,14 @@ else
       Chef::Log.debug "ufw:rule:interface #{params['interface']}" if params['interface']
       Chef::Log.debug "ufw:rule:logging #{params['logging']}" if params['logging']
       Chef::Log.debug "ufw:rule:port #{params['port']}" if params['port']
+      Chef::Log.debug "ufw:rule:port_range #{params['port_range']}" if params['port_range']
       Chef::Log.debug "ufw:rule:source #{params['source']}" if params['source']
       Chef::Log.debug "ufw:rule:destination #{params['destination']}" if params['destination']
       Chef::Log.debug "ufw:rule:dest_port #{params['dest_port']}" if params['dest_port']
       Chef::Log.debug "ufw:rule:position #{params['position']}" if params['position']
       act = params['action']
       act ||= "allow"
+      raise "ufw: port_range was specified to firewall_rule without protocol" if params['port_range'] && !params['protocol']
       Chef::Log.debug "ufw:rule:action :#{act}"
       firewall_rule rule do
         name params['name'] if params['name']
@@ -72,7 +74,10 @@ else
         interface params['interface'] if params['interface']
         logging params['logging'].to_sym if params['logging']
         port params['port'].to_i if params['port']
-        port_range eval params['port_range'] if params['port_range']
+	if params['port_range']
+	  ends = params['port_range'].split('..').map{|d| Integer(d)}
+	  port_range ends[0]..ends[1]
+	end
         source params['source'] if params['source']
         destination params['destination'] if params['destination']
         dest_port params['dest_port'].to_i if params['dest_port']


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3592

The source port of a firewall rule can be defined as a range e.g. port_range => "1000..1024"
