### PR TITLE
Add node['firewall']['configuration'] for adjusting /etc/default/ufw

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ default
 -------
 The `default` recipe looks for the list of firewall rules to apply from the `['firewall']['rules']` attribute added to roles and on the node itself. The list of rules is then applied to the node in the order specified.
 
+The `default` recipe also applies any `['firewall']['configuration']` values to /etc/default/ufw.
+
 disable
 -------
 The `disable` recipe is used if there is a need to disable the existing firewall, perhaps for testing. It disables the ufw firewall even if other ufw recipes attempt to enable it.
@@ -92,6 +94,20 @@ Roles and the node may have the `['firewall']['rules']` attribute set. This attr
             }
           }
         ]
+      }
+      )
+
+Roles and the node may have the `['firewall']['configuration']` attribute set. This attribute is a hash, and each key-value pair will be assigned in /etc/default/ufw. For example:
+
+    name "fw_configuration_example"
+    description "Firewall confirutation for Examples"
+    override_attributes(
+      "firewall" => {
+        "configuration" => {
+          'IPV6' => 'no',
+          'DEFAULT_FORWARD_POLICY' => 'ACCEPT',
+          'SOME_ARBITRARY_SETTING' => 'ARBITRARY_VALUE',
+        }
       }
       )
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ recipes
 -------
 The `recipes` recipe applies firewall rules based on inspecting the runlist for recipes that have node[<recipe>]['firewall']['rules'] attributes. These are appended to node['firewall']['rules'] and applied to the node. Cookbooks may define attributes for recipes like so:
 
+```ruby
 # attributes/default.rb for test cookbook
     default['test']['firewall']['rules'] = [
       {"test"=> {
@@ -51,6 +52,7 @@ The `recipes` recipe applies firewall rules based on inspecting the runlist for 
          }
        }
     ]
+```
 
 Note that the 'test::awesome' rules are only applied if that specific recipe is in the runlist. Recipe-applied firewall rules are applied after any rules defined in role attributes.
 
@@ -63,6 +65,7 @@ Attributes
 Roles and the node may have the `['firewall']['rules']` attribute set. This attribute is a list of hashes, the key will be rule name, the value will be the hash of parameters. Application order is based on run list.
 
 # Example Role
+```ruby
     name "fw_example"
     description "Firewall rules for Examples"
     override_attributes(
@@ -96,9 +99,11 @@ Roles and the node may have the `['firewall']['rules']` attribute set. This attr
         ]
       }
       )
+```
 
 Roles and the node may have the `['firewall']['configuration']` attribute set. This attribute is a hash, and each key-value pair will be assigned in /etc/default/ufw. For example:
 
+```ruby
     name "fw_configuration_example"
     description "Firewall confirutation for Examples"
     override_attributes(
@@ -110,6 +115,7 @@ Roles and the node may have the `['firewall']['configuration']` attribute set. T
         }
       }
       )
+```
 
 Data Bags
 =========
@@ -123,6 +129,7 @@ The items in the data bag will contain a 'rules' array of hashes to apply to the
 
 # Example 'firewall' data bag item
 
+```json
     {
         "id": "apache2",
         "rules": [
@@ -136,6 +143,7 @@ The items in the data bag will contain a 'rules' array of hashes to apply to the
             }}
         ]
     }
+```
 
 Resources/Providers
 ===================

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,4 @@
+default['firewall']['configuration_file'] = "/etc/default/ufw"
+default['firewall']['configuration']      = {}
 default['firewall']['rules'] = []
 default['firewall']['securitylevel'] = ""

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -1,0 +1,35 @@
+#
+# Author:: rchekaluk
+# Cookbook Name:: ufw
+# Recipe:: configure
+#
+# Copyright 2015, Opscode, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+node['firewall']['configuration'].each_pair do |key,value|
+
+  bash "Assign ufw configuration value" do
+    code <<-EOH
+      if [ -n "`grep '#{key}=' #{node['firewall']['configuration_file']}`" ]; then
+        sed -i '/#{key}=/ s|=.*$|="#{value}"|' #{node['firewall']['configuration_file']}
+      else
+        echo "#{key}=#{value}" >> #{node['firewall']['configuration_file']}
+      fi
+    EOH
+    notifies :restart, 'service[ufw]', :delayed
+  end
+
+end
+

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -22,14 +22,16 @@ node['firewall']['configuration'].each_pair do |key,value|
 
   bash "Assign ufw configuration value" do
     code <<-EOH
-      if [ -n "`grep '#{key}=' #{node['firewall']['configuration_file']}`" ]; then
-        sed -i '/#{key}=/ s|=.*$|="#{value}"|' #{node['firewall']['configuration_file']}
+      if [ -n "`egrep '^[[:space:]]*#{key}=' #{node['firewall']['configuration_file']}`" ]; then
+        sed -i '/^[[:space:]]*#{key}=/ s|=.*$|="#{value}"|' #{node['firewall']['configuration_file']}
       else
-        echo "#{key}=#{value}" >> #{node['firewall']['configuration_file']}
+        echo '#{key}="#{value}"' >> #{node['firewall']['configuration_file']}
       fi
     EOH
     notifies :restart, 'service[ufw]', :delayed
-  end
+    not_if "egrep \"^[[:space:]]*#{key}=['\\\"]{,1}#{value}['\\\"]{,1}\" #{node['firewall']['configuration_file']}"
+
+  end unless key.nil? || key == ''
 
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,6 +20,12 @@
 
 package "ufw"
 
+service "ufw" do
+  supports :status => true, :restart => true, :reload => false
+end
+
+include_recipe "ufw::configure"
+
 old_state = node['firewall']['state']
 new_state = node['firewall']['rules'].to_s
 Chef::Log.debug "Old firewall state:#{old_state}"


### PR DESCRIPTION
Supports a new attribute node['firewall']['configuration'] as a hash containing arbitrary ufw settings to be assigned in [/etc/default/ufw](https://wiki.ubuntu.com/UncomplicatedFirewall#Advanced_Functionality). The recipe is idempotent and will add new settings to /etc/default/ufw, but edit settings if they exist already.

Example usage for using [ufw with Docker](https://docs.docker.com/installation/ubuntulinux/#docker-and-ufw):

``` ruby
    firewall_rules = {
      :firewall => {
        :configuration => {
          'DEFAULT_FORWARD_POLICY' => 'ACCEPT',
        },
        :rules => [
          {"docker_remote_api" => { "port" => "2375" } },
        ]
      }
    }
```
