### PR TITLE
Add item to README to help Chef10/11 users from getting caught out by open-ended version dependency which requires Chef12 and poise

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Requirements
 ============
 Tested with Ubuntu 10.04 and 11.04.
 
+Since this cookbook has an open-ended dependency on 'firewall', users of Chef11 or earlier should pin
+'firewall' to '~>0.9' via the caller's metadata. Otherwise 'poise' v2+ will be invoked which is Chef12+ only.
+
 Recipes
 =======
 default

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          "Apache 2.0"
 description      "Installs/Configures ufw"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.7.5"
-depends          "firewall", ">= 0.9"
+depends          "firewall", "~> 0.9"
 
 %w{ ubuntu }.each do |os|
   supports os

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          "Apache 2.0"
 description      "Installs/Configures ufw"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.7.5"
-depends          "firewall", "~> 0.9"
+depends          "firewall", ">= 0.9"
 
 %w{ ubuntu }.each do |os|
   supports os


### PR DESCRIPTION
should fix https://github.com/opscode-cookbooks/ufw/issues/16