### PR TITLE
Fixing to work with latest version of firewall cookbook

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,13 +37,13 @@ else
   execute 'ufw --force reset'
 
   firewall 'ufw' do
-    action :enable
+    action :install
   end
 
   # leave this on by default
   firewall_rule 'ssh' do
     port 22
-    action :allow
+    action :create
   end
 
   node['firewall']['rules'].each do |rule_mash|

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -64,7 +64,7 @@ else
       Chef::Log.debug "ufw:rule:dest_port #{params['dest_port']}" if params['dest_port']
       Chef::Log.debug "ufw:rule:position #{params['position']}" if params['position']
       act = params['action']
-      act ||= 'allow'
+      act ||= 'create'
       fail 'ufw: port_range was specified to firewall_rule without protocol' if params['port_range'] && !params['protocol']
       Chef::Log.debug "ufw:rule:action :#{act}"
       firewall_rule rule do


### PR DESCRIPTION
The firewall and firewall_rule actions have changed in the latest version of the firewall cookbook. 

Fixes errors:
```
Chef::Exceptions::ValidationFailed
----------------------------------
Option action must be equal to one of: nothing, install, restart, disable, flush, save!  You passed :enable.
```
```
Chef::Exceptions::ValidationFailed
----------------------------------
Option action must be equal to one of: nothing, create!  You passed :allow.
```

I suspect there is more that needs fixing within the libraries but I've not got that far yet.