### PR TITLE
Choose to disable default ssh rule

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['firewall']['rules'] = []
 default['firewall']['securitylevel'] = ''
+default['firewall']['default_ssh'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,6 +45,7 @@ else
   firewall_rule 'ssh' do
     port 22
     action :create
+    only_if {node['firewall']['default_ssh']}
   end
 
   node['firewall']['rules'].each do |rule_mash|


### PR DESCRIPTION
### Description

Let user to choose to enable or diable the default ssh rule

### Issues Resolved


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

