### PR TITLE
Add guard to firewall ssh rule in default recipe using the firewall attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # ufw Cookbook CHANGELOG
 This file is used to list changes made in each version of the ufw cookbook.
 
+## 3.1.0 (2017-03-01)
+- Add use of the default['firewall']['allow_ssh'] attribute in the default recipe. Default for this cookbook is set to true, as the default recipe assumed that ssh would be enabled.
+
 ## 3.0.0 (2017-03-01)
 - Require Chef 12.4 (Depends on firewall which requires Chef 12.4+ at this point)
 - Update default to remove installation of ufw which is duplication from firewall cookbook, and remove state changes

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ override_attributes(
   )
 ```
 
+* default['firewall']['allow_ssh'] Opens port 22 for SSH when set to true. Default set to true.
+
 ## Data Bags
 
 The `firewall` data bag may be used with the `databag` recipe. It will contain items that map to role names (eg. the 'apache' role will map to the 'apache' item in the 'firewall' data bag). Either roles or recipes may be keys (role[webserver] is 'webserver', recipe[apache2] is 'apache2'). If you have recipe-specific firewall rules, you will need to replace the '::' with '**' (double underscores) (eg. recipe[apache2::mod_ssl] is 'apache2**mod_ssl' in the data bag item).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,3 @@
 default['firewall']['rules'] = []
 default['firewall']['securitylevel'] = ''
+default['firewall']['allow_ssh'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,7 @@ end
 firewall_rule 'ssh' do
   port 22
   action :create
+  only_if { node['firewall']['allow_ssh'] }
 end
 
 node['firewall']['rules'].each do |rule_mash|


### PR DESCRIPTION
Signed-off-by: Jennifer Davis <iennae@gmail.com>

### Description

Add guard to firewall ssh rule in default recipe using the firewall attribute
### Issues Resolved

Issue #12 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
