### PR TITLE
Allow rules attribute to be defined as hash

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Installs and configures Uncomplicated Firewall (ufw)'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.1.0'
+version          '3.2.0'
 depends          'firewall', '>= 2.0'
 
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,43 +29,52 @@ firewall_rule 'ssh' do
   only_if { node['firewall']['allow_ssh'] }
 end
 
-node['firewall']['rules'].each do |rule_mash|
-  Chef::Log.debug "ufw:rule \"#{rule_mash}\""
-  rule_mash.keys.each do |rule|
-    Chef::Log.debug "ufw:rule:name \"#{rule}\""
-    params = rule_mash[rule]
-    Chef::Log.debug "ufw:rule:parameters \"#{params}\""
-    Chef::Log.debug "ufw:rule:name #{params['name']}" if params['name']
-    Chef::Log.debug "ufw:rule:protocol #{params['protocol']}" if params['protocol']
-    Chef::Log.debug "ufw:rule:direction #{params['direction']}" if params['direction']
-    Chef::Log.debug "ufw:rule:interface #{params['interface']}" if params['interface']
-    Chef::Log.debug "ufw:rule:logging #{params['logging']}" if params['logging']
-    Chef::Log.debug "ufw:rule:port #{params['port']}" if params['port']
-    Chef::Log.debug "ufw:rule:port_range #{params['port_range']}" if params['port_range']
-    Chef::Log.debug "ufw:rule:source #{params['source']}" if params['source']
-    Chef::Log.debug "ufw:rule:destination #{params['destination']}" if params['destination']
-    Chef::Log.debug "ufw:rule:dest_port #{params['dest_port']}" if params['dest_port']
-    Chef::Log.debug "ufw:rule:position #{params['position']}" if params['position']
-    act = params['action']
-    act ||= 'create'
-    raise 'ufw: port_range was specified to firewall_rule without protocol' if params['port_range'] && !params['protocol']
-    Chef::Log.debug "ufw:rule:action :#{act}"
-    firewall_rule rule do
-      name params['name'] if params['name']
-      protocol params['protocol'].to_sym if params['protocol']
-      direction params['direction'].to_sym if params['direction']
-      interface params['interface'] if params['interface']
-      logging params['logging'].to_sym if params['logging']
-      port params['port'].to_i if params['port']
-      if params['port_range']
-        ends = params['port_range'].split('..').map { |d| Integer(d) }
-        port_range ends[0]..ends[1]
-      end
-      source params['source'] if params['source']
-      destination params['destination'] if params['destination']
-      dest_port params['dest_port'].to_i if params['dest_port']
-      position params['position'].to_i if params['position']
-      action act
+# handle rules specified as array or as hash
+rules = {}
+if node['firewall']['rules'].is_a?(Array)
+  node['firewall']['rules'].each do |rule_mash|
+    rule_mash.keys.each do |rule|
+      rules[rule] = rule_mash[rule]
     end
+  end
+elsif node['firewall']['rules'].is_a?(Hash)
+  rules = node['firewall']['rules']
+end
+
+rules.keys.each do |rule|
+  Chef::Log.debug "ufw:rule:name \"#{rule}\""
+  params = rules[rule]
+  Chef::Log.debug "ufw:rule:parameters \"#{params}\""
+  Chef::Log.debug "ufw:rule:name #{params['name']}" if params['name']
+  Chef::Log.debug "ufw:rule:protocol #{params['protocol']}" if params['protocol']
+  Chef::Log.debug "ufw:rule:direction #{params['direction']}" if params['direction']
+  Chef::Log.debug "ufw:rule:interface #{params['interface']}" if params['interface']
+  Chef::Log.debug "ufw:rule:logging #{params['logging']}" if params['logging']
+  Chef::Log.debug "ufw:rule:port #{params['port']}" if params['port']
+  Chef::Log.debug "ufw:rule:port_range #{params['port_range']}" if params['port_range']
+  Chef::Log.debug "ufw:rule:source #{params['source']}" if params['source']
+  Chef::Log.debug "ufw:rule:destination #{params['destination']}" if params['destination']
+  Chef::Log.debug "ufw:rule:dest_port #{params['dest_port']}" if params['dest_port']
+  Chef::Log.debug "ufw:rule:position #{params['position']}" if params['position']
+  act = params['action']
+  act ||= 'create'
+  raise 'ufw: port_range was specified to firewall_rule without protocol' if params['port_range'] && !params['protocol']
+  Chef::Log.debug "ufw:rule:action :#{act}"
+  firewall_rule rule do
+    name params['name'] if params['name']
+    protocol params['protocol'].to_sym if params['protocol']
+    direction params['direction'].to_sym if params['direction']
+    interface params['interface'] if params['interface']
+    logging params['logging'].to_sym if params['logging']
+    port params['port'].to_i if params['port']
+    if params['port_range']
+      ends = params['port_range'].split('..').map { |d| Integer(d) }
+      port_range ends[0]..ends[1]
+    end
+    source params['source'] if params['source']
+    destination params['destination'] if params['destination']
+    dest_port params['dest_port'].to_i if params['dest_port']
+    position params['position'].to_i if params['position']
+    action act
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,4 +5,6 @@ RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
+  config.platform = 'ubuntu'
+  config.version = '16.04'
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,25 +1,45 @@
 require 'spec_helper'
 
 describe 'ufw::default' do
-  cached(:chef_run) do
-    ChefSpec::ServerRunner.new do |node, _server|
-      node.normal['firewall']['rules'] = [
-        { 'http'  => { 'port' => '80'  } },
-      ]
-      node.override['firewall']['rules'] = [
-        { 'https' => { 'port' => '443' } },
-      ]
-    end.converge(described_recipe)
+  context 'rules attribute is Array' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new do |node, _server|
+        node.normal['firewall']['rules'] = [
+          { 'http'  => { 'port' => '80'  } },
+          { 'https' => { 'port' => '443' } },
+        ]
+      end.converge(described_recipe)
+    end
+
+    it 'calls firewall rule for each ' do
+      expect(chef_run).to create_firewall_rule('http').with(
+        port: 80,
+        protocol: :tcp
+      )
+      expect(chef_run).to create_firewall_rule('https').with(
+        port: 443,
+        protocol: :tcp
+      )
+    end
   end
 
-  it 'calls firewall rule for each ' do
-    expect(chef_run).to create_firewall_rule('http').with(
-      port: 80,
-      protocol: :tcp
-    )
-    expect(chef_run).to create_firewall_rule('https').with(
-      port: 443,
-      protocol: :tcp
-    )
+  context 'rules attribute is Hash' do
+    cached(:chef_run) do
+      ChefSpec::ServerRunner.new do |node, _server|
+        node.normal['firewall']['rules']   = { 'http'  => { 'port' => '80'  } }
+        node.override['firewall']['rules'] = { 'https' => { 'port' => '443' } }
+      end.converge(described_recipe)
+    end
+
+    it 'calls firewall rule for each ' do
+      expect(chef_run).to create_firewall_rule('http').with(
+        port: 80,
+        protocol: :tcp
+      )
+      expect(chef_run).to create_firewall_rule('https').with(
+        port: 443,
+        protocol: :tcp
+      )
+    end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,11 +1,25 @@
 require 'spec_helper'
 
 describe 'ufw::default' do
-  let(:chef_run) do
-    ChefSpec::ServerRunner.converge(described_recipe)
+  cached(:chef_run) do
+    ChefSpec::ServerRunner.new do |node, _server|
+      node.normal['firewall']['rules'] = [
+        { 'http'  => { 'port' => '80'  } },
+      ]
+      node.override['firewall']['rules'] = [
+        { 'https' => { 'port' => '443' } },
+      ]
+    end.converge(described_recipe)
   end
 
-  it 'converges successfully' do
-    expect { :chef_run }.to_not raise_error
+  it 'calls firewall rule for each ' do
+    expect(chef_run).to create_firewall_rule('http').with(
+      port: 80,
+      protocol: :tcp
+    )
+    expect(chef_run).to create_firewall_rule('https').with(
+      port: 443,
+      protocol: :tcp
+    )
   end
 end


### PR DESCRIPTION
### Description

This allows rules to be defined as a Hash in the `['firewall']['rules']` attribute. This is beneficial because each cookbook can specify in the attribute what rules it needs, and if some are `default` and some are `override` precedence, the attribute will still merge.

### Issues Resolved

fixes #33 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
