### PR TITLE
Hotfix for using 'concat' in recipes

### DIFF
--- a/recipes/databag.rb
+++ b/recipes/databag.rb
@@ -51,7 +51,7 @@ rlist.each do |entry|
   # add the list of firewall rules to the current list
   item = data_bag_item('firewall', entry)
   rules = item['rules']
-  node.normal['firewall']['rules'].concat(rules) unless rules.nil?
+  node.normal['firewall']['rules'] = node.normal['firewall']['rules'].to_a.concat(rules) unless rules.nil?
 end
 
 # now go apply the rules

--- a/recipes/recipes.rb
+++ b/recipes/recipes.rb
@@ -34,7 +34,7 @@ node.expand!.recipes.each do |recipe|
 
   rules = node[recipe]['firewall']['rules']
   Chef::Log.debug "ufw::recipes:#{recipe}:rules #{rules}"
-  node.normal['firewall']['rules'].concat(rules) unless rules.nil?
+  node.normal['firewall']['rules'] = node.normal['firewall']['rules'].to_a.concat(rules) unless rules.nil?
 end
 
 # now go apply the rules


### PR DESCRIPTION
### Issues Resolved

Fixes:
```
================================================================================
Recipe Compile Error in /tmp/kitchen/cache/cookbooks/ufw/recipes/databag.rb
================================================================================

NoMethodError
-------------
Undefined node attribute or method `concat' on `node'. To set an attribute, use `concat=value' instead.
```
- https://github.com/chef-cookbooks/ufw/issues/32

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
