### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source 'https://rubygems.org'
 
 gem 'cookstyle'
 gem 'chefspec', '>= 9.3.7'
-gem 'berkshelf'
 gem 'fauxhai-chef'
 gem 'rspec-its'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'ufw'
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'ufw', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -10,6 +10,7 @@ transport:
 
 provisioner:
   name: dokken
+  chef_license: accept
 
 platforms:
   - name: debian-12

--- a/resources/ufw_firewall.rb
+++ b/resources/ufw_firewall.rb
@@ -43,8 +43,8 @@ action_class do
 
   def desired_rules_file(rule_resources)
     build_rule_file(
-      rule_resources.each_with_object({}) do |rule_resource, rules|
-        rules[build_rule(rule_resource)] = rule_resource.position
+      rule_resources.to_h do |rule_resource|
+        [build_rule(rule_resource), rule_resource.position]
       end
     )
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- add Policyfile.rb for test cookbook and dependency resolution
- remove Berksfile and Berkshelf packaging references
- switch ChefSpec setup to chefspec/policyfile
- remove berkshelf from Gemfile

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list